### PR TITLE
Add drag selection for log list, Add Text Selection mode and UI improvements

### DIFF
--- a/src/main/kotlin/ui/MainScreen.kt
+++ b/src/main/kotlin/ui/MainScreen.kt
@@ -309,6 +309,9 @@ fun MainScreen(
                             isAlt -> viewModel.toggleSingleLogSelection(id)
                             else -> viewModel.selectSingleLog(id)
                         }
+                    },
+                    onDragSelect = { id ->
+                        viewModel.selectRangeLog(id)
                     }
                 )
             }

--- a/src/main/kotlin/vm/MainViewModel.kt
+++ b/src/main/kotlin/vm/MainViewModel.kt
@@ -22,6 +22,11 @@ import java.io.File
 import java.text.SimpleDateFormat
 import java.util.Date
 
+enum class SelectionMode {
+    LogItem,
+    Text
+}
+
 data class UiState(
     val logLevelFilter: LogLevel? = null,
     val filterPid: Int? = null,
@@ -31,7 +36,8 @@ data class UiState(
     val filteredLogs: ImmutableList<LogcatMessage> = persistentListOf(),
     val allLogCount: Int = 0,
     val bookmarkCount: Int = 0,
-    val bookmarkedIndicesInFilteredLogs: ImmutableList<Int> = persistentListOf()
+    val bookmarkedIndicesInFilteredLogs: ImmutableList<Int> = persistentListOf(),
+    val selectionMode: SelectionMode = SelectionMode.LogItem
 )
 
 class MainViewModel(
@@ -371,6 +377,23 @@ class MainViewModel(
             allLogs[index] = allLogs[index].copy(isBookmarked = !allLogs[index].isBookmarked)
             updateFilteredLogs()
         }
+    }
+
+    fun toggleTextSelectionMode() {
+        val currentMode = _uiState.value.selectionMode
+        val newMode = if (currentMode == SelectionMode.LogItem) SelectionMode.Text else SelectionMode.LogItem
+
+        // When switching to Text mode, deselect all logs
+        if (newMode == SelectionMode.Text) {
+            for (i in allLogs.indices) {
+                if (allLogs[i].isSelected) {
+                    allLogs[i] = allLogs[i].copy(isSelected = false)
+                }
+            }
+        }
+
+        _uiState.value = _uiState.value.copy(selectionMode = newMode)
+        updateFilteredLogs()
     }
 
     fun scrollToFilteredLogIndex(index: Int): Long? {


### PR DESCRIPTION
[LogMeow] Add drag selection for log list
    - Enable multi-select by dragging: hold mouse button and drag to select multiple logs
    - Auto-scroll when dragging outside list bounds (up/down)
    - Disable drag mode when Ctrl/Cmd is pressed (toggle selection mode)

[LogMeow] Add Text Selection mode and UI improvements
    - Add SelectionMode (LogItem/Text) with Cmd+T toggle
    - Text Selection mode: select text across log rows, scroll disabled
    - Show "Text Selection" badge in status bar when mode is active
    - Disable auto-scroll during Text Selection mode
    - Match device dropdown menu width to button (300dp)